### PR TITLE
Fix Icons & Add Event to pause walking styles

### DIFF
--- a/client/walking.lua
+++ b/client/walking.lua
@@ -1,6 +1,7 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 local walkstyle = 'default'
 local walktable = {}
+local walkpause = false
 
 RegisterNetEvent("QBCore:Client:OnPlayerLoaded", function()
     Wait(2000)
@@ -11,6 +12,10 @@ RegisterNetEvent("QBCore:Client:OnPlayerLoaded", function()
     if walktable[PlayerData.citizenid] then
         walkstyle = walktable[PlayerData.citizenid]
     end
+end)
+
+RegisterNetEvent('ps-walks:walkpause', function()
+	walkpause = not walkpause
 end)
 
 AddEventHandler('onResourceStart', function(resourceName)
@@ -56,11 +61,13 @@ end)
 CreateThread(function()
     while true do
         Wait(1000)
-        local ped = PlayerPedId()
-        local walkstyleCurrent = GetPedMovementClipset(ped)
-        if walkstyleCurrent ~= joaat(walkstyle) or walkstyle == "default" then
-            SetWalks(walkstyle)
-        end
+		if not walkpause then
+			local ped = PlayerPedId()
+			local walkstyleCurrent = GetPedMovementClipset(ped)
+			if walkstyleCurrent ~= joaat(walkstyle) or walkstyle == "default" then
+				SetWalks(walkstyle)
+			end
+		end
     end
 end)
 
@@ -68,54 +75,54 @@ CreateThread(function()
     local walkId = exports['qb-radialmenu']:AddOption({
         id = 'walkstyles',
         title = 'Walkstyle',
-        icon = 'walking',
+        icon = 'person-walking',
         items = {
             {
                 id = 'arrogant',
                 title = 'Arrogant',
-                icon = 'walking',
+                icon = 'person-walking',
                 type = 'client',
                 event = 'ps-walks:set',
                 shouldClose = true
             }, {
                 id = 'casual',
                 title = 'Casual',
-                icon = 'walking',
+                icon = 'person-walking',
                 type = 'client',
                 event = 'ps-walks:set',
                 shouldClose = true
             }, {
                 id = 'casual2',
                 title = 'Casual 2',
-                icon = 'walking',
+                icon = 'person-walking',
                 type = 'client',
                 event = 'ps-walks:set',
                 shouldClose = true
             }, {
                 id = 'casual3',
                 title = 'Casual 3',
-                icon = 'walking',
+                icon = 'person-walking',
                 type = 'client',
                 event = 'ps-walks:set',
                 shouldClose = true
             }, {
                 id = 'casual4',
                 title = 'Casual4',
-                icon = 'walking',
+                icon = 'person-walking',
                 type = 'client',
                 event = 'ps-walks:set',
                 shouldClose = true
             }, {
                 id = 'casual5',
                 title = 'Casual 5',
-                icon = 'walking',
+                icon = 'person-walking',
                 type = 'client',
                 event = 'ps-walks:set',
                 shouldClose = true
             }, {
                 id = 'casual6',
                 title = 'Casual 6',
-                icon = 'walking',
+                icon = 'person-walking',
                 type = 'client',
                 event = 'ps-walks:set',
                 shouldClose = true
@@ -127,49 +134,49 @@ CreateThread(function()
                     {
                         id = 'confident',
                         title = 'Confident',
-                        icon = 'walking',
+                        icon = 'person-walking',
                         type = 'client',
                         event = 'ps-walks:set',
                         shouldClose = true
                     }, {
                         id = 'business',
                         title = 'Business',
-                        icon = 'walking',
+                        icon = 'person-walking',
                         type = 'client',
                         event = 'ps-walks:set',
                         shouldClose = true
                     }, {
                         id = 'business2',
                         title = 'Business 2',
-                        icon = 'walking',
+                        icon = 'person-walking',
                         type = 'client',
                         event = 'ps-walks:set',
                         shouldClose = true
                     }, {
                         id = 'business3',
                         title = 'Business 3',
-                        icon = 'walking',
+                        icon = 'person-walking',
                         type = 'client',
                         event = 'ps-walks:set',
                         shouldClose = true
                     }, {
                         id = 'femme',
                         title = 'Femme',
-                        icon = 'walking',
+                        icon = 'person-walking',
                         type = 'client',
                         event = 'ps-walks:set',
                         shouldClose = true
                     }, {
                         id = 'flee',
                         title = 'Flee',
-                        icon = 'walking',
+                        icon = 'person-walking',
                         type = 'client',
                         event = 'ps-walks:set',
                         shouldClose = true
                     }, {
                         id = 'muscle',
                         title = 'Muscle',
-                        icon = 'walking',
+                        icon = 'person-walking',
                         type = 'client',
                         event = 'ps-walks:set',
                         shouldClose = true
@@ -182,49 +189,49 @@ CreateThread(function()
                            {
                                 id = 'gangster',
                                 title = 'Gangster',
-                                icon = 'walking',
+                                icon = 'person-walking',
                                 type = 'client',
                                 event = 'ps-walks:set',
                                 shouldClose = true
                             }, {
                                 id = 'gangster2',
                                 title = 'Gangster 2',
-                                icon = 'walking',
+                                icon = 'person-walking',
                                 type = 'client',
                                 event = 'ps-walks:set',
                                 shouldClose = true
                             }, {
                                 id = 'gangster3',
                                 title = 'Gangster 3',
-                                icon = 'walking',
+                                icon = 'person-walking',
                                 type = 'client',
                                 event = 'ps-walks:set',
                                 shouldClose = true
                             }, {
                                 id = 'gangster4',
                                 title = 'Gangster 4',
-                                icon = 'walking',
+                                icon = 'person-walking',
                                 type = 'client',
                                 event = 'ps-walks:set',
                                 shouldClose = true
                             }, {
                                 id = 'gangster5',
                                 title = 'Gangster 5',
-                                icon = 'walking',
+                                icon = 'person-walking',
                                 type = 'client',
                                 event = 'ps-walks:set',
                                 shouldClose = true
                             }, {
                                 id = 'heels',
                                 title = 'Heels',
-                                icon = 'walking',
+                                icon = 'person-walking',
                                 type = 'client',
                                 event = 'ps-walks:set',
                                 shouldClose = true
                             }, {
                                 id = 'heels2',
                                 title = 'Heels 2',
-                                icon = 'walking',
+                                icon = 'person-walking',
                                 type = 'client',
                                 event = 'ps-walks:set',
                                 shouldClose = true
@@ -237,49 +244,49 @@ CreateThread(function()
                                     {
                                         id = 'hiking',
                                         title = 'Hiking',
-                                        icon = 'walking',
+                                        icon = 'person-walking',
                                         type = 'client',
                                         event = 'ps-walks:set',
                                         shouldClose = true
                                     }, {
                                         id = 'quick',
                                         title = 'Quick',
-                                        icon = 'walking',
+                                        icon = 'person-walking',
                                         type = 'client',
                                         event = 'ps-walks:set',
                                         shouldClose = true
                                     }, {
                                         id = 'wide',
                                         title = 'Wide',
-                                        icon = 'walking',
+                                        icon = 'person-walking',
                                         type = 'client',
                                         event = 'ps-walks:set',
                                         shouldClose = true
                                     }, {
                                         id = 'scared',
                                         title = 'Scared',
-                                        icon = 'walking',
+                                        icon = 'person-walking',
                                         type = 'client',
                                         event = 'ps-walks:set',
                                         shouldClose = true
                                     }, {
                                         id = 'brave',
                                         title = 'Brave',
-                                        icon = 'walking',
+                                        icon = 'person-walking',
                                         type = 'client',
                                         event = 'ps-walks:set',
                                         shouldClose = true
                                     }, {
                                         id = 'tipsy',
                                         title = 'Tipsy',
-                                        icon = 'walking',
+                                        icon = 'person-walking',
                                         type = 'client',
                                         event = 'ps-walks:set',
                                         shouldClose = true
                                     }, {
                                         id = 'injured',
                                         title = 'Injured',
-                                        icon = 'walking',
+                                        icon = 'person-walking',
                                         type = 'client',
                                         event = 'ps-walks:set',
                                         shouldClose = true
@@ -292,49 +299,49 @@ CreateThread(function()
                                             {
                                                 id = 'tough',
                                                 title = 'Tough',
-                                                icon = 'walking',
+                                                icon = 'person-walking',
                                                 type = 'client',
                                                 event = 'ps-walks:set',
                                                 shouldClose = true
                                             }, {
                                                 id = 'sassy',
                                                 title = 'Sassy',
-                                                icon = 'walking',
+                                                icon = 'person-walking',
                                                 type = 'client',
                                                 event = 'ps-walks:set',
                                                 shouldClose = true
                                             }, {
                                                 id = 'sad',
                                                 title = 'Sad',
-                                                icon = 'walking',
+                                                icon = 'person-walking',
                                                 type = 'client',
                                                 event = 'ps-walks:set',
                                                 shouldClose = true
                                             }, {
                                                 id = 'posh',
                                                 title = 'Posh',
-                                                icon = 'walking',
+                                                icon = 'person-walking',
                                                 type = 'client',
                                                 event = 'ps-walks:set',
                                                 shouldClose = true
                                             }, {
                                                 id = 'alien',
                                                 title = 'Alien',
-                                                icon = 'walking',
+                                                icon = 'person-walking',
                                                 type = 'client',
                                                 event = 'ps-walks:set',
                                                 shouldClose = true
                                             }, {
                                                 id = 'nonchalant',
                                                 title = 'Nonchalant',
-                                                icon = 'walking',
+                                                icon = 'person-walking',
                                                 type = 'client',
                                                 event = 'ps-walks:set',
                                                 shouldClose = true
                                             }, {
                                                 id = 'hobo',
                                                 title = 'Hobo',
-                                                icon = 'walking',
+                                                icon = 'person-walking',
                                                 type = 'client',
                                                 event = 'ps-walks:set',
                                                 shouldClose = true
@@ -347,42 +354,42 @@ CreateThread(function()
                                                     {
                                                         id = 'money',
                                                         title = 'Money',
-                                                        icon = 'walking',
+                                                        icon = 'person-walking',
                                                         type = 'client',
                                                         event = 'ps-walks:set',
                                                         shouldClose = true
                                                     }, {
                                                         id = 'swagger',
                                                         title = 'Swagger',
-                                                        icon = 'walking',
+                                                        icon = 'person-walking',
                                                         type = 'client',
                                                         event = 'ps-walks:set',
                                                         shouldClose = true
                                                     }, {
                                                         id = 'shady',
                                                         title = 'Shady',
-                                                        icon = 'walking',
+                                                        icon = 'person-walking',
                                                         type = 'client',
                                                         event = 'ps-walks:set',
                                                         shouldClose = true
                                                     }, {
                                                         id = 'maneater',
                                                         title = 'Man Eater',
-                                                        icon = 'walking',
+                                                        icon = 'person-walking',
                                                         type = 'client',
                                                         event = 'ps-walks:set',
                                                         shouldClose = true
                                                     }, {
                                                         id = 'chichi',
                                                         title = 'Chichi',
-                                                        icon = 'walking',
+                                                        icon = 'person-walking',
                                                         type = 'client',
                                                         event = 'ps-walks:set',
                                                         shouldClose = true
                                                     }, {
                                                         id = 'default',
                                                         title = 'Default',
-                                                        icon = 'walking',
+                                                        icon = 'person-walking',
                                                         type = 'client',
                                                         event = 'ps-walks:set',
                                                         shouldClose = true


### PR DESCRIPTION
Useful if you have a script that temporarily changes your walking style, i.e. Drunk walk. This event allows you pause the walkstyle system until you call the event again to re-enable it.